### PR TITLE
`load_paths` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Dassets.configure do |c|
 
     # register for `sass` syntax
     s.engine 'sass', Dassets::Sass::Engine, :syntax => 'sass'
+
+    # by default `/path/to/assets` is in the load paths, but
+    # you can specify additional custom load paths to use with `@import`s
+    s.engine 'scss', Dassets::Sass::Engine, {
+      :syntax => 'scss',
+      :load_paths => ['/custom/load/path']
+    }
   end
 
 end

--- a/dassets-sass.gemspec
+++ b/dassets-sass.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.10"])
+  gem.add_development_dependency("assert", ["~> 2.12"])
 
   # lock in to Sass 3.1 and up b/c this is earliest version implementing
   # the expected `Sass.compile` api:

--- a/lib/dassets-sass.rb
+++ b/lib/dassets-sass.rb
@@ -10,12 +10,20 @@ module Dassets::Sass
       (self.opts[:syntax] || self.opts['syntax'] || 'scss').to_s
     end
 
+    def load_paths
+      @load_paths ||= ([self.opts['source_path']] +
+                       [*(self.opts[:load_paths] || self.opts['load_paths'] || [])])
+    end
+
     def ext(input_ext)
       'css'
     end
 
     def compile(input_content)
-      ::Sass.compile(input_content, :syntax => self.syntax.to_sym)
+      ::Sass.compile(input_content, {
+        :syntax => self.syntax.to_sym,
+        :load_paths => self.load_paths
+      })
     end
 
   end

--- a/test/unit/engine_tests.rb
+++ b/test/unit/engine_tests.rb
@@ -8,11 +8,13 @@ class Dassets::Sass::Engine
   class UnitTests < Assert::Context
     desc "Dassets::Sass::Engine"
     setup do
+      @lp1 = '/a-load-path-1'
+      @lp2 = '/a-load-path-2'
       @engine = Dassets::Sass::Engine.new
     end
     subject{ @engine }
 
-    should have_instance_method :syntax
+    should have_imeths :syntax, :load_paths
 
     should "be a Dassets engine" do
       assert_kind_of Dassets::Engine, subject
@@ -28,11 +30,49 @@ class Dassets::Sass::Engine
       assert_equal 'sass', Dassets::Sass::Engine.new(:syntax => 'sass').syntax
     end
 
+    should "default the load paths to be just the source path" do
+      assert_equal [subject.opts['source_path']], subject.load_paths
+    end
+
+    should "allow specifying custom load paths, always including the source path" do
+      engine = Dassets::Sass::Engine.new(:load_paths => @lp1)
+      assert_includes @lp1, engine.load_paths
+      assert_includes subject.opts['source_path'], engine.load_paths
+
+      engine = Dassets::Sass::Engine.new('load_paths' => [@lp1])
+      assert_includes @lp1, engine.load_paths
+      assert_includes subject.opts['source_path'], engine.load_paths
+
+      engine = Dassets::Sass::Engine.new('load_paths' => [@lp1, @lp2])
+      assert_includes @lp1, engine.load_paths
+      assert_includes @lp2, engine.load_paths
+      assert_includes subject.opts['source_path'], engine.load_paths
+    end
+
     should "transform any input extension to `css`" do
       assert_equal 'css', subject.ext('scss')
       assert_equal 'css', subject.ext('sass')
       assert_equal 'css', subject.ext('sassycss')
       assert_equal 'css', subject.ext('whatever')
+    end
+
+    should "use its syntax and load paths when compiling" do
+      compiled_with_options = false
+      input = @factory.sass
+      syntax = :sass
+      sass_engine = Dassets::Sass::Engine.new({
+        :syntax => syntax,
+        :load_paths => [@lp1]
+      })
+      load_paths = sass_engine.load_paths
+
+      Assert.stub(::Sass, :compile).with(input, {
+        :syntax => syntax,
+        :load_paths => load_paths
+      }){ compiled_with_options = true }
+
+      sass_engine.compile(input)
+      assert_true compiled_with_options
     end
 
     should "compile any input content as Sass css" do


### PR DESCRIPTION
Use this to specify custom load paths.  These will be used with
`@import` statements.

The engine's load paths will always include the 'source_path' option
provided by Dassets when the engine is configured.

Note: this also adds a test to ensure that sass is compiled with
the appropriate options.  This required updating to the latest
Assert to get its stubbing API.

@jcredding ready for review.
