### PR TITLE
`output_style` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,17 @@ Dassets.configure do |c|
     # register for `sass` syntax
     s.engine 'sass', Dassets::Sass::Engine, :syntax => 'sass'
 
+    # by default `:nested` output style is used, but you can
+    # specify a custom style (http://sass-lang.com/documentation/file.SASS_REFERENCE.html#output_style)
+    s.engine 'scss', Dassets::Sass::Engine, {
+      ...
+      :output_style => :compressed
+    }
+
     # by default `/path/to/assets` is in the load paths, but
     # you can specify additional custom load paths to use with `@import`s
     s.engine 'scss', Dassets::Sass::Engine, {
-      :syntax => 'scss',
+      ...
       :load_paths => ['/custom/load/path']
     }
   end

--- a/lib/dassets-sass.rb
+++ b/lib/dassets-sass.rb
@@ -10,6 +10,10 @@ module Dassets::Sass
       (self.opts[:syntax] || self.opts['syntax'] || 'scss').to_s
     end
 
+    def output_style
+      (self.opts[:output_style] || self.opts['output_style'] || 'nested').to_s
+    end
+
     def load_paths
       @load_paths ||= ([self.opts['source_path']] +
                        [*(self.opts[:load_paths] || self.opts['load_paths'] || [])])
@@ -22,6 +26,7 @@ module Dassets::Sass
     def compile(input_content)
       ::Sass.compile(input_content, {
         :syntax => self.syntax.to_sym,
+        :style  => self.output_style.to_sym,
         :load_paths => self.load_paths
       })
     end

--- a/test/unit/engine_tests.rb
+++ b/test/unit/engine_tests.rb
@@ -14,7 +14,7 @@ class Dassets::Sass::Engine
     end
     subject{ @engine }
 
-    should have_imeths :syntax, :load_paths
+    should have_imeths :syntax, :output_style, :load_paths
 
     should "be a Dassets engine" do
       assert_kind_of Dassets::Engine, subject
@@ -23,11 +23,21 @@ class Dassets::Sass::Engine
     end
 
     should "default the syntax to `scss`" do
-      assert_equal 'scss', Dassets::Sass::Engine.new.syntax
+      assert_equal 'scss', subject.syntax
     end
 
-    should "allow specifying the engine syntax using engine opts" do
-      assert_equal 'sass', Dassets::Sass::Engine.new(:syntax => 'sass').syntax
+    should "allow specifying a custom syntax value" do
+      engine = Dassets::Sass::Engine.new(:syntax => 'sass')
+      assert_equal 'sass', engine.syntax
+    end
+
+    should "default the output style to `nested`" do
+      assert_equal 'nested', subject.output_style
+    end
+
+    should "allow specifying a custom output style value" do
+      engine = Dassets::Sass::Engine.new(:output_style => 'compressed')
+      assert_equal 'compressed', engine.output_style
     end
 
     should "default the load paths to be just the source path" do
@@ -56,18 +66,21 @@ class Dassets::Sass::Engine
       assert_equal 'css', subject.ext('whatever')
     end
 
-    should "use its syntax and load paths when compiling" do
+    should "use its syntax, output style and load paths when compiling" do
       compiled_with_options = false
       input = @factory.sass
       syntax = :sass
+      output_style = :compressed
       sass_engine = Dassets::Sass::Engine.new({
         :syntax => syntax,
+        :output_style => output_style,
         :load_paths => [@lp1]
       })
       load_paths = sass_engine.load_paths
 
       Assert.stub(::Sass, :compile).with(input, {
         :syntax => syntax,
+        :style => output_style,
         :load_paths => load_paths
       }){ compiled_with_options = true }
 


### PR DESCRIPTION
Use this to specify a custom output_style
(http://sass-lang.com/documentation/file.SASS_REFERENCE.html#output_style).

This will default, as before, to using the `nested` output style.  This allows
users to specify a custom output style (ie `compressed` or whatever).

@jcredding ready for review.
