### PR TITLE
get working in modern ruby versions

### DIFF
--- a/dassets-sass.gemspec
+++ b/dassets-sass.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.15.1"])
+  gem.add_development_dependency("assert", ["~> 2.16.1"])
 
   # lock in to Sass 3.1 and up b/c this is earliest version implementing
   # the expected `Sass.compile` api:
   # https://github.com/nex3/sass/commit/332dd6945a8acd660719e0ea4eb48ae3a3ef9b38
   gem.add_dependency("sass",    ["~> 3.1"])
-  gem.add_dependency("dassets", ["~> 0.13.2"])
+  gem.add_dependency("dassets", ["~> 0.14.0"])
 
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,9 +7,19 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
-ENV['DASSETS_TEST_MODE']   = 'yes'
-
 require 'test/support/factory'
+
 class Assert::Context
-  setup{ @factory = Dassets::Sass::Factory }
+  setup{ @factory = Factory }
 end
+
+# 1.8.7 backfills
+
+# Array#sample
+if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
+  class Array
+    alias_method :sample, :choice
+  end
+end
+
+ENV['DASSETS_TEST_MODE']   = 'yes'

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,37 +1,37 @@
-module Dassets::Sass
+require 'assert/factory'
 
-  module Factory
-    module_function
+module Factory
+  extend Assert::Factory
 
-    def scss
-      "$blue: #3bbfce;\n"\
-      "$margin: 16px;\n"\
-      ".border {\n"\
-      "  padding: $margin / 2;\n"\
-      "  margin: $margin / 2;\n"\
-      "  border-color: $blue;\n"\
-      "}\n"
-    end
+  module_function
 
-    def scss_compiled
-      ".border {\n"\
-      "  padding: 8px;\n"\
-      "  margin: 8px;\n"\
-      "  border-color: #3bbfce; "\
-      "}\n"
-    end
+  def scss
+    "$blue: #3bbfce;\n"\
+    "$margin: 16px;\n"\
+    ".border {\n"\
+    "  padding: $margin / 2;\n"\
+    "  margin: $margin / 2;\n"\
+    "  border-color: $blue;\n"\
+    "}\n"
+  end
 
-    def sass
-      "table.hl\n"\
-      "  margin: 2em 0\n"\
-    end
+  def scss_compiled
+    ".border {\n"\
+    "  padding: 8px;\n"\
+    "  margin: 8px;\n"\
+    "  border-color: #3bbfce; "\
+    "}\n"
+  end
 
-    def sass_compiled
-      "table.hl {\n"\
-      "  margin: 2em 0; "\
-      "}\n"\
-    end
+  def sass
+    "table.hl\n"\
+    "  margin: 2em 0\n"\
+  end
 
+  def sass_compiled
+    "table.hl {\n"\
+    "  margin: 2em 0; "\
+    "}\n"\
   end
 
 end


### PR DESCRIPTION
This updates the gem dependencies to bring in the latest versions
(which also now work in modern ruby versions) and updates the test
suite to get up to convention for working in modern ruby versions.
This includes backfilling Array#sample so it works in 1.8.7.

Note: I also reworked the support Factory to be more up to our
latest conventions.  This caused no behavior changes, though.

@jcredding ready for review.