### PR TITLE
update dependencies; update to latest conventions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,7 @@
 source "https://rubygems.org"
 
+ruby "~> 2.5"
+
 gemspec
 
-gem 'pry',  "~> 0.9.0"
-gem 'rack', " = 1.6.8"
-
-# lock in sass to 3.4.21 as 3.5+ will no longer support ruby 1.8.7
-# also 3.4.22 adds a huge deprecation warning that we don't care about
-gem 'sass', "= 3.4.21"
+gem "pry", "~> 0.12.2"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dassets::Sass
 
-Dassets [engine](https://github.com/redding/dassets#compiling) for compiling [Sass](http://sass-lang.com/) css sources using [libsass](https://github.com/sass/sassc-ruby).
+Dassets [engine](https://github.com/redding/dassets#compiling) to compile dynamic asset filtes written with [SASS/SCSS](http://sass-lang.com/) using [libsass](https://github.com/sass/sassc-ruby).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dassets::Sass
 
-Dassets [engine](https://github.com/redding/dassets#compiling) for compiling [Sass](http://sass-lang.com/) css sources.
+Dassets [engine](https://github.com/redding/dassets#compiling) for compiling [Sass](http://sass-lang.com/) css sources using [libsass](https://github.com/sass/sassc-ruby).
 
 ## Usage
 
@@ -8,43 +8,41 @@ Register the engine:
 
 ```ruby
 # in config/assets.rb
-require 'dassets'
-require 'dassets-sass'
+require "dassets"
+require "dassets-sass"
 
 Dassets.configure do |c|
-
   c.source "/path/to/assets") do |s|
     # register for `scss` syntax
-    s.engine 'scss', Dassets::Sass::Engine, :syntax => 'scss'
+    s.engine "scss", Dassets::Sass::Engine, syntax: Dassets::Sass::SCSS
 
     # register for `sass` syntax
-    s.engine 'sass', Dassets::Sass::Engine, :syntax => 'sass'
+    s.engine "sass", Dassets::Sass::Engine, syntax: Dassets::Sass::SASS
 
-    # by default `:nested` output style is used, but you can
+    # by default Dassets::Sass::NESTED output style is used, but you can
     # specify a custom style (http://sass-lang.com/documentation/file.SASS_REFERENCE.html#output_style)
-    s.engine 'scss', Dassets::Sass::Engine, {
+    s.engine "scss", Dassets::Sass::Engine, {
       ...
-      :output_style => :compressed
+      output_style: Dassets::Sass::COMPRESSED
     }
 
-    # by default `/path/to/assets` is in the load paths, but
+    # by default `/path/to/assets` is in the load path, but
     # you can specify additional custom load paths to use with `@import`s
-    s.engine 'scss', Dassets::Sass::Engine, {
+    s.engine "scss", Dassets::Sass::Engine, {
       ...
-      :load_paths => ['/custom/load/path']
+      load_paths: ["/custom/load/path"]
     }
   end
-
 end
 ```
 
-Put your `.scss` and `.sass` source files in your source path.  Dassets will compile their content using Sass, switch their extension to `.css`, and write the output to the output path.
+Put your `.scss` and `.sass` source files in your source path. Dassets will compile their content using Sass, switch their extension to `.css`, and write the output to the output path.
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
-    gem 'dassets-sass'
+    gem "dassets-sass"
 
 And then execute:
 

--- a/dassets-sass.gemspec
+++ b/dassets-sass.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "dassets-sass/version"
 
@@ -11,19 +11,15 @@ Gem::Specification.new do |gem|
   gem.summary     = %q{Dassets engine for compiling Sass}
   gem.description = %q{Dassets engine for compiling Sass}
   gem.homepage    = "http://github.com/redding/dassets-sass"
-  gem.license     = 'MIT'
+  gem.license     = "MIT"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.16.3"])
+  gem.add_development_dependency("assert", ["~> 2.19.0"])
 
-  # lock in to Sass 3.1 and up b/c this is earliest version implementing
-  # the expected `Sass.compile` api:
-  # https://github.com/nex3/sass/commit/332dd6945a8acd660719e0ea4eb48ae3a3ef9b38
-  gem.add_dependency("sass",    ["~> 3.1"])
-  gem.add_dependency("dassets", ["~> 0.14.5"])
-
+  gem.add_dependency("dassets", ["~> 0.15.0"])
+  gem.add_dependency("sassc",   ["~> 2.0"])
 end

--- a/lib/dassets-sass.rb
+++ b/lib/dassets-sass.rb
@@ -1,36 +1,72 @@
-require 'sass'
-require 'dassets/engine'
+# frozen_string_literal: true
+
+require "sassc"
+require "dassets/engine"
 require "dassets-sass/version"
 
 module Dassets::Sass
-
-  class Engine < Dassets::Engine
-
-    def syntax
-      (self.opts[:syntax] || self.opts['syntax'] || 'scss').to_s
-    end
-
-    def output_style
-      (self.opts[:output_style] || self.opts['output_style'] || 'nested').to_s
-    end
-
-    def load_paths
-      @load_paths ||= ([self.opts['source_path']] +
-                       [*(self.opts[:load_paths] || self.opts['load_paths'] || [])])
-    end
-
-    def ext(input_ext)
-      'css'
-    end
-
-    def compile(input_content)
-      ::Sass.compile(input_content, {
-        :syntax => self.syntax.to_sym,
-        :style  => self.output_style.to_sym,
-        :load_paths => self.load_paths
-      })
-    end
-
+  def self.SASS
+    "sass"
   end
 
+  def self.SCSS
+    "scss"
+  end
+
+  def self.NESTED
+    "nested"
+  end
+
+  def self.EXPANDED
+    "expanded"
+  end
+
+  def self.COMPACT
+    "compact"
+  end
+
+  def self.COMPRESSED
+    "compressed"
+  end
+end
+
+class Dassets::Sass::Engine < Dassets::Engine
+  def syntax
+    (
+      self.opts[:syntax] ||
+      self.opts["syntax"] ||
+      Dassets::Sass.SCSS
+    ).to_s
+  end
+
+  def output_style
+    (
+      self.opts[:output_style] ||
+      self.opts["output_style"] ||
+      Dassets::Sass.NESTED
+    ).to_s
+  end
+
+  def load_paths
+    @load_paths ||=
+      (
+        [self.opts["source_path"]] +
+        [*(self.opts[:load_paths] || self.opts["load_paths"] || [])]
+      )
+  end
+
+  def ext(input_ext)
+    "css"
+  end
+
+  def compile(input_content)
+    SassC::Engine
+      .new(
+        input_content,
+        syntax:     self.syntax.to_sym,
+        style:      self.output_style.to_sym,
+        load_paths: self.load_paths,
+      )
+      .render
+  end
 end

--- a/lib/dassets-sass/version.rb
+++ b/lib/dassets-sass/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Dassets; end
 module Dassets::Sass
   VERSION = "0.4.0"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,21 +5,12 @@
 $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
 # require pry for debugging (`binding.pry`)
-require 'pry'
+require "pry"
 
-require 'test/support/factory'
+require "test/support/factory"
 
 class Assert::Context
   setup{ @factory = Factory }
 end
 
-# 1.8.7 backfills
-
-# Array#sample
-if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
-  class Array
-    alias_method :sample, :choice
-  end
-end
-
-ENV['DASSETS_TEST_MODE']   = 'yes'
+ENV["DASSETS_TEST_MODE"] = "yes"

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,4 +1,4 @@
-require 'assert/factory'
+require "assert/factory"
 
 module Factory
   extend Assert::Factory

--- a/test/unit/dassets-sass_tests.rb
+++ b/test/unit/dassets-sass_tests.rb
@@ -4,26 +4,33 @@ require "dassets-sass"
 require "dassets/engine"
 require "sassc"
 
-class Dassets::Sass::Engine
+module Dassets::Sass
   class UnitTests < Assert::Context
-    desc "Dassets::Sass::Engine"
+    desc "Dassets::Sass"
     subject { unit_class }
 
-    let(:unit_class) { Dassets::Sass::Engine }
+    let(:unit_class) { Dassets::Sass }
 
     should "know its CONSTANTS" do
-      assert_that(Dassets::Sass.SASS).equals("sass")
-      assert_that(Dassets::Sass.SCSS).equals("scss")
-      assert_that(Dassets::Sass.NESTED).equals("nested")
-      assert_that(Dassets::Sass.EXPANDED).equals("expanded")
-      assert_that(Dassets::Sass.COMPACT).equals("compact")
-      assert_that(Dassets::Sass.COMPRESSED).equals("compressed")
+      assert_that(unit_class.SASS).equals("sass")
+      assert_that(unit_class.SCSS).equals("scss")
+      assert_that(unit_class.NESTED).equals("nested")
+      assert_that(unit_class.EXPANDED).equals("expanded")
+      assert_that(unit_class.COMPACT).equals("compact")
+      assert_that(unit_class.COMPRESSED).equals("compressed")
     end
   end
 
-  class InitTests < UnitTests
+  class EngineTests < UnitTests
+    desc "Engine"
+    subject { engine_class }
+
+    let(:engine_class) { unit_class::Engine }
+  end
+
+  class EngineInitTests < EngineTests
     desc "when init"
-    subject { unit_class.new }
+    subject { engine_class.new }
 
     setup do
       @lp1 = "/a-load-path-1"
@@ -46,7 +53,7 @@ class Dassets::Sass::Engine
 
     should "allow specifying a custom settings" do
       engine =
-        Dassets::Sass::Engine.new(
+        engine_class.new(
           syntax:       Dassets::Sass.SASS,
           output_style: Dassets::Sass.COMPRESSED,
         )
@@ -55,15 +62,15 @@ class Dassets::Sass::Engine
     end
 
     should "allow specifying custom load paths, always including the source path" do
-      engine = Dassets::Sass::Engine.new(load_paths: @lp1)
+      engine = engine_class.new(load_paths: @lp1)
       assert_that(engine.load_paths).includes(@lp1)
       assert_that(engine.load_paths).includes(subject.opts["source_path"])
 
-      engine = Dassets::Sass::Engine.new("load_paths" => [@lp1])
+      engine = engine_class.new("load_paths" => [@lp1])
       assert_that(engine.load_paths).includes(@lp1)
       assert_that(engine.load_paths).includes(subject.opts["source_path"])
 
-      engine = Dassets::Sass::Engine.new("load_paths" => [@lp1, @lp2])
+      engine = engine_class.new("load_paths" => [@lp1, @lp2])
       assert_that(engine.load_paths).includes(@lp1)
       assert_that(engine.load_paths).includes(@lp2)
       assert_that(engine.load_paths).includes(subject.opts["source_path"])
@@ -79,7 +86,7 @@ class Dassets::Sass::Engine
     should "use its syntax, output style and load paths when compiling" do
       load_paths = [@lp1]
       sass_engine =
-        Dassets::Sass::Engine.new(
+        engine_class.new(
           syntax:       Dassets::Sass.SASS,
           output_style: Dassets::Sass.COMPRESSED,
           load_paths:   load_paths,
@@ -104,7 +111,7 @@ class Dassets::Sass::Engine
     should "compile any input content as Sass CSS" do
       assert_equal @factory.scss_compiled, subject.compile(@factory.scss)
 
-      sass_engine = Dassets::Sass::Engine.new(syntax: Dassets::Sass.SASS)
+      sass_engine = engine_class.new(syntax: Dassets::Sass.SASS)
       assert_equal @factory.sass_compiled, sass_engine.compile(@factory.sass)
     end
   end

--- a/test/unit/engine_tests.rb
+++ b/test/unit/engine_tests.rb
@@ -1,100 +1,111 @@
-require 'assert'
-require 'dassets-sass'
+require "assert"
+require "dassets-sass"
 
-require 'dassets/engine'
+require "dassets/engine"
+require "sassc"
 
 class Dassets::Sass::Engine
-
   class UnitTests < Assert::Context
     desc "Dassets::Sass::Engine"
-    setup do
-      @lp1 = '/a-load-path-1'
-      @lp2 = '/a-load-path-2'
-      @engine = Dassets::Sass::Engine.new
+    subject { unit_class }
+
+    let(:unit_class) { Dassets::Sass::Engine }
+
+    should "know its CONSTANTS" do
+      assert_that(Dassets::Sass.SASS).equals("sass")
+      assert_that(Dassets::Sass.SCSS).equals("scss")
+      assert_that(Dassets::Sass.NESTED).equals("nested")
+      assert_that(Dassets::Sass.EXPANDED).equals("expanded")
+      assert_that(Dassets::Sass.COMPACT).equals("compact")
+      assert_that(Dassets::Sass.COMPRESSED).equals("compressed")
     end
-    subject{ @engine }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { unit_class.new }
+
+    setup do
+      @lp1 = "/a-load-path-1"
+      @lp2 = "/a-load-path-2"
+    end
 
     should have_imeths :syntax, :output_style, :load_paths
 
     should "be a Dassets engine" do
-      assert_kind_of Dassets::Engine, subject
-      assert_respond_to 'ext', subject
-      assert_respond_to 'compile', subject
+      assert_that(subject).is_kind_of(Dassets::Engine)
+      assert_that(subject).responds_to("ext")
+      assert_that(subject).responds_to("compile")
     end
 
-    should "default the syntax to `scss`" do
-      assert_equal 'scss', subject.syntax
+    should "default its settings" do
+      assert_that(subject.syntax).equals(Dassets::Sass.SCSS)
+      assert_that(subject.output_style).equals(Dassets::Sass.NESTED)
+      assert_that(subject.load_paths).equals([subject.opts["source_path"]])
     end
 
-    should "allow specifying a custom syntax value" do
-      engine = Dassets::Sass::Engine.new(:syntax => 'sass')
-      assert_equal 'sass', engine.syntax
-    end
-
-    should "default the output style to `nested`" do
-      assert_equal 'nested', subject.output_style
-    end
-
-    should "allow specifying a custom output style value" do
-      engine = Dassets::Sass::Engine.new(:output_style => 'compressed')
-      assert_equal 'compressed', engine.output_style
-    end
-
-    should "default the load paths to be just the source path" do
-      assert_equal [subject.opts['source_path']], subject.load_paths
+    should "allow specifying a custom settings" do
+      engine =
+        Dassets::Sass::Engine.new(
+          syntax:       Dassets::Sass.SASS,
+          output_style: Dassets::Sass.COMPRESSED,
+        )
+      assert_that(engine.syntax).equals(Dassets::Sass.SASS)
+      assert_that(engine.output_style).equals(Dassets::Sass.COMPRESSED)
     end
 
     should "allow specifying custom load paths, always including the source path" do
-      engine = Dassets::Sass::Engine.new(:load_paths => @lp1)
-      assert_includes @lp1, engine.load_paths
-      assert_includes subject.opts['source_path'], engine.load_paths
+      engine = Dassets::Sass::Engine.new(load_paths: @lp1)
+      assert_that(engine.load_paths).includes(@lp1)
+      assert_that(engine.load_paths).includes(subject.opts["source_path"])
 
-      engine = Dassets::Sass::Engine.new('load_paths' => [@lp1])
-      assert_includes @lp1, engine.load_paths
-      assert_includes subject.opts['source_path'], engine.load_paths
+      engine = Dassets::Sass::Engine.new("load_paths" => [@lp1])
+      assert_that(engine.load_paths).includes(@lp1)
+      assert_that(engine.load_paths).includes(subject.opts["source_path"])
 
-      engine = Dassets::Sass::Engine.new('load_paths' => [@lp1, @lp2])
-      assert_includes @lp1, engine.load_paths
-      assert_includes @lp2, engine.load_paths
-      assert_includes subject.opts['source_path'], engine.load_paths
+      engine = Dassets::Sass::Engine.new("load_paths" => [@lp1, @lp2])
+      assert_that(engine.load_paths).includes(@lp1)
+      assert_that(engine.load_paths).includes(@lp2)
+      assert_that(engine.load_paths).includes(subject.opts["source_path"])
     end
 
     should "transform any input extension to `css`" do
-      assert_equal 'css', subject.ext('scss')
-      assert_equal 'css', subject.ext('sass')
-      assert_equal 'css', subject.ext('sassycss')
-      assert_equal 'css', subject.ext('whatever')
+      assert_that(subject.ext("scss")).equals("css")
+      assert_that(subject.ext("sass")).equals("css")
+      assert_that(subject.ext("sassycss")).equals("css")
+      assert_that(subject.ext("whatever")).equals("css")
     end
 
     should "use its syntax, output style and load paths when compiling" do
-      compiled_with_options = false
-      input = @factory.sass
-      syntax = :sass
-      output_style = :compressed
-      sass_engine = Dassets::Sass::Engine.new({
-        :syntax => syntax,
-        :output_style => output_style,
-        :load_paths => [@lp1]
-      })
-      load_paths = sass_engine.load_paths
+      load_paths = [@lp1]
+      sass_engine =
+        Dassets::Sass::Engine.new(
+          syntax:       Dassets::Sass.SASS,
+          output_style: Dassets::Sass.COMPRESSED,
+          load_paths:   load_paths,
+        )
 
-      Assert.stub(::Sass, :compile).with(input, {
-        :syntax => syntax,
-        :style => output_style,
-        :load_paths => load_paths
-      }){ compiled_with_options = true }
+      render_spy =
+        Assert.stub_spy(::SassC::Engine, :new, render: "rendered output")
 
-      sass_engine.compile(input)
-      assert_true compiled_with_options
+      input  = @factory.sass
+      output = sass_engine.compile(input)
+
+      assert_that(output).equals("rendered output")
+      assert_that(render_spy.new_called_with.pargs).equals([input])
+      assert_that(render_spy.new_called_with.kargs)
+        .equals(
+          syntax:     Dassets::Sass.SASS.to_sym,
+          style:      Dassets::Sass.COMPRESSED.to_sym,
+          load_paths: ([sass_engine.opts["source_path"]] + load_paths),
+        )
     end
 
-    should "compile any input content as Sass css" do
+    should "compile any input content as Sass CSS" do
       assert_equal @factory.scss_compiled, subject.compile(@factory.scss)
 
-      sass_engine = Dassets::Sass::Engine.new :syntax => 'sass'
+      sass_engine = Dassets::Sass::Engine.new(syntax: Dassets::Sass.SASS)
       assert_equal @factory.sass_compiled, sass_engine.compile(@factory.sass)
     end
-
   end
-
 end


### PR DESCRIPTION
This gets the gem on the latest dependencies and updates the
source to our latest conventions.

Note: this switches to using libsass via [SassC](https://github.com/sass/sassc-ruby).
See https://sass-lang.com/ruby-sass for details.

# Other Changes

### update README, tests based on latest conventions

I noticed these updates as I was looking at Dassets::Erb while I 
was writing Dassets::Erubi.